### PR TITLE
Update FilesConfig.java

### DIFF
--- a/src/main/java/com/files/FilesConfig.java
+++ b/src/main/java/com/files/FilesConfig.java
@@ -18,6 +18,8 @@ public class FilesConfig {
       properties.load(file);
     } catch (IOException e) {
       log.warn("could not load configurator properties");
+    } catch (NullPointerException ne) {
+      log.warn("could not load configurator properties /files-sdk.properties could not be located");
     }
   }
 


### PR DESCRIPTION
A missing config file exception will still escape the try-catch block. 

Can cause a little confusion because it _looks_ like the existing catch should be preventing a crash

NOTE: this exception is not thrown in the maven build - only when I download the SDK and run it manually. A bit of exploration shows that the maven build contains the missing file. If it is intentionally omitted from the SDK, the exception might want to throw a more informative error